### PR TITLE
tune block heigh poll interval and block finality confirmations count

### DIFF
--- a/cmd/iconbridge/chain/bsc/receiver.go
+++ b/cmd/iconbridge/chain/bsc/receiver.go
@@ -23,9 +23,10 @@ import (
 
 const (
 	BlockInterval              = 3 * time.Second
-	BlockHeightPollInterval    = 60 * time.Second
+	BlockHeightPollInterval    = 15 * time.Second
+	BlockFinalityConfirmations = 10
+	// TODO: adapt BlockHeightPollInterval depending on the value of BlockInterval or BlockFinalityConfirmations to avoid drift
 	MonitorBlockMaxConcurrency = 300 // number of concurrent requests to synchronize older blocks from source chain
-	BlockConfirmationInterval  = 5
 	RPCCallRetry               = 5
 )
 
@@ -250,7 +251,7 @@ func (r *receiver) receiveLoop(ctx context.Context, opts *BnOptions, callback fu
 			r.log.WithFields(log.Fields{"error": err}).Error("receiveLoop: failed to GetBlockNumber")
 			return 0
 		}
-		return height - BlockConfirmationInterval
+		return height - BlockFinalityConfirmations
 	}
 	next, latest := opts.StartHeight, latestHeight()
 

--- a/cmd/iconbridge/relay/relay.go
+++ b/cmd/iconbridge/relay/relay.go
@@ -204,7 +204,7 @@ func (r *relay) Start(ctx context.Context) error {
 					r.log.WithFields(log.Fields{"id": tx.ID(), "error": err}).Error("tx.Send failed")
 					return err
 				case errors.Is(err, chain.ErrInsufficientBalance):
-					r.log.WithFields(log.Fields{"error": err}).Error(
+					r.log.WithFields(log.Fields{"error": err}).Errorf(
 						"add balance to relay account: waiting for %v", relayInsufficientBalanceWaitInterval)
 					time.Sleep(relayInsufficientBalanceWaitInterval)
 				default:


### PR DESCRIPTION
This is an ad-hoc solution until we implement full BSC header chain verification.