### PR TITLE
Bugfix/300 bmr config balance threshold encoding in scientific notation

### DIFF
--- a/cmd/iconbridge/chain/bsc/sender.go
+++ b/cmd/iconbridge/chain/bsc/sender.go
@@ -30,6 +30,7 @@ import (
 	ethtypes "github.com/ethereum/go-ethereum/core/types"
 	"github.com/icon-project/icon-bridge/cmd/iconbridge/chain"
 	"github.com/icon-project/icon-bridge/common/codec"
+	"github.com/icon-project/icon-bridge/common/intconv"
 	"github.com/icon-project/icon-bridge/common/log"
 	"github.com/icon-project/icon-bridge/common/wallet"
 )
@@ -72,10 +73,10 @@ const (
 */
 
 type senderOptions struct {
-	GasLimit         uint64  `json:"gas_limit"`
-	TxDataSizeLimit  uint64  `json:"tx_data_size_limit"`
-	BoostGasPrice    float64 `json:"boost_gas_price"`
-	BalanceThreshold big.Int `json:"balance_threshold"`
+	GasLimit         uint64         `json:"gas_limit"`
+	TxDataSizeLimit  uint64         `json:"tx_data_size_limit"`
+	BoostGasPrice    float64        `json:"boost_gas_price"`
+	BalanceThreshold intconv.BigInt `json:"balance_threshold"`
 }
 
 type sender struct {
@@ -220,7 +221,7 @@ func (s *sender) Segment(
 func (s *sender) Balance(ctx context.Context) (balance, threshold *big.Int, err error) {
 	cl, _ := s.jointClient()
 	bal, err := cl.GetBalance(ctx, s.w.Address())
-	return bal, &s.opts.BalanceThreshold, err
+	return bal, &s.opts.BalanceThreshold.Int, err
 }
 
 func (s *sender) newRelayTx(ctx context.Context, prev string, message []byte, gasPrice *big.Int) (*relayTx, error) {

--- a/cmd/iconbridge/chain/hmny/sender.go
+++ b/cmd/iconbridge/chain/hmny/sender.go
@@ -17,6 +17,7 @@ import (
 	ethtypes "github.com/ethereum/go-ethereum/core/types"
 	"github.com/icon-project/icon-bridge/cmd/iconbridge/chain"
 	"github.com/icon-project/icon-bridge/common/codec"
+	"github.com/icon-project/icon-bridge/common/intconv"
 	"github.com/icon-project/icon-bridge/common/log"
 	"github.com/icon-project/icon-bridge/common/wallet"
 )
@@ -63,10 +64,10 @@ func NewSender(
 }
 
 type senderOptions struct {
-	GasLimit         uint64  `json:"gas_limit"`
-	BoostGasPrice    float64 `json:"boost_gas_price"`
-	TxDataSizeLimit  uint64  `json:"tx_data_size_limit"`
-	BalanceThreshold big.Int `json:"balance_threshold"`
+	GasLimit         uint64         `json:"gas_limit"`
+	BoostGasPrice    float64        `json:"boost_gas_price"`
+	TxDataSizeLimit  uint64         `json:"tx_data_size_limit"`
+	BalanceThreshold intconv.BigInt `json:"balance_threshold"`
 }
 
 func (opts *senderOptions) Unmarshal(v map[string]interface{}) error {
@@ -183,7 +184,7 @@ func (s *sender) Segment(
 func (s *sender) Balance(ctx context.Context) (balance, threshold *big.Int, err error) {
 	cl, _ := s.jointClient()
 	bal, err := cl.GetBalance(ctx, s.w.Address())
-	return bal, &s.opts.BalanceThreshold, err
+	return bal, &s.opts.BalanceThreshold.Int, err
 
 }
 

--- a/cmd/iconbridge/chain/icon/sender.go
+++ b/cmd/iconbridge/chain/icon/sender.go
@@ -29,6 +29,7 @@ import (
 	"github.com/icon-project/icon-bridge/cmd/iconbridge/chain"
 	"github.com/icon-project/icon-bridge/common"
 	"github.com/icon-project/icon-bridge/common/codec"
+	"github.com/icon-project/icon-bridge/common/intconv"
 	"github.com/icon-project/icon-bridge/common/jsonrpc"
 	"github.com/icon-project/icon-bridge/common/log"
 	"github.com/icon-project/icon-bridge/common/wallet"
@@ -66,9 +67,9 @@ func NewSender(
 }
 
 type senderOptions struct {
-	StepLimit        uint64  `json:"step_limit"`
-	TxDataSizeLimit  uint64  `json:"tx_data_size_limit"`
-	BalanceThreshold big.Int `json:"balance_threshold"`
+	StepLimit        uint64         `json:"step_limit"`
+	TxDataSizeLimit  uint64         `json:"tx_data_size_limit"`
+	BalanceThreshold intconv.BigInt `json:"balance_threshold"`
 }
 
 func (opts *senderOptions) Unmarshal(v map[string]interface{}) error {
@@ -193,7 +194,7 @@ func (s *sender) Segment(
 
 func (s *sender) Balance(ctx context.Context) (balance, threshold *big.Int, err error) {
 	bal, err := s.cl.GetBalance(&AddressParam{Address: Address(s.w.Address())})
-	return bal, &s.opts.BalanceThreshold, err
+	return bal, &s.opts.BalanceThreshold.Int, err
 }
 
 func (s *sender) newRelayTx(ctx context.Context, prev string, message []byte) (*relayTx, error) {

--- a/common/intconv/bigint.go
+++ b/common/intconv/bigint.go
@@ -1,0 +1,31 @@
+package intconv
+
+import (
+	"encoding/json"
+	"math"
+	"math/big"
+)
+
+type BigInt struct {
+	big.Int
+}
+
+func (i BigInt) MarshalJSON() ([]byte, error) {
+	if i.Int.Cmp(big.NewInt(math.MaxInt64)) > 0 {
+		return json.Marshal(i.String())
+	}
+	return json.Marshal(i.Int64())
+}
+
+func (i *BigInt) UnmarshalJSON(b []byte) error {
+	err := json.Unmarshal(b, &i.Int)
+	if err != nil {
+		var str string
+		err = json.Unmarshal(b, &str)
+		if err != nil {
+			return err
+		}
+		i.Int.SetString(str, 10)
+	}
+	return nil
+}

--- a/common/intconv/bigint_test.go
+++ b/common/intconv/bigint_test.go
@@ -1,0 +1,25 @@
+package intconv
+
+import (
+	"encoding/json"
+	"math"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestBigIntLessThanMaxInt64MarshalJSON(t *testing.T) {
+	i := BigInt{}
+	i.SetInt64(math.MaxInt64)
+	b, err := json.Marshal(i)
+	require.NoError(t, err)
+	require.Equal(t, "9223372036854775807", string(b))
+}
+
+func TestBigIntGreaterThanMaxInt64MarshalJSON(t *testing.T) {
+	i := BigInt{}
+	i.SetUint64(math.MaxUint64)
+	b, err := json.Marshal(i)
+	require.NoError(t, err)
+	require.Equal(t, `"18446744073709551615"`, string(b))
+}

--- a/devnet/docker/icon-bsc/scripts/deploysc.sh
+++ b/devnet/docker/icon-bsc/scripts/deploysc.sh
@@ -206,7 +206,7 @@ generate_relay_config() {
         --argfile dst_key_store "$CONFIG_DIR/keystore/icon.bmr.wallet.json" \
         --arg dst_key_store_cointype "icx" \
         --arg dst_key_password "$(cat $CONFIG_DIR/keystore/icon.bmr.wallet.secret)" \
-        --argjson dst_options '{"step_limit":13610920010, "tx_data_size_limit":8192,"balance_threshold":10000000000000000000}'
+        --argjson dst_options '{"step_limit":2500000000, "tx_data_size_limit":8192,"balance_threshold":"10000000000000000000"}'
     )" \
     --argjson i2b_relay "$(
       jq -n '
@@ -235,7 +235,7 @@ generate_relay_config() {
         --arg dst_key_store_cointype "evm" \
         --arg dst_key_password "$(cat $CONFIG_DIR/keystore/bsc.bmr.wallet.secret)" \
         --argjson dst_tx_data_size_limit 8192 \
-        --argjson dst_options '{"gas_limit":24000000,"tx_data_size_limit":8192,"balance_threshold":100000000000000000000,"boost_gas_price":1.0}'
+        --argjson dst_options '{"gas_limit":24000000,"tx_data_size_limit":8192,"balance_threshold":"100000000000000000000","boost_gas_price":1.0}'
     )"
 }
 


### PR DESCRIPTION
@andrii-kl,
Using string for big.Int, as you suggested was a standard practice, seems like a simpler fix. Can you please review this? I've created a custom BigInt type to be used with minimal addition of new code. We can reuse this type whenever we need to pass big.Int from config as string.