### PR TITLE
chore: add dependency review, update gitignore, lint pr

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -1,0 +1,12 @@
+name: 'Dependency Review'
+on: [pull_request]
+permissions:
+  contents: read
+jobs:
+  dependency-review:
+    runs-on: ubuntu-latest
+    steps:
+      - name: 'Checkout Repository'
+        uses: actions/checkout@v3
+      - name: Dependency Review
+        uses: actions/dependency-review-action@v2

--- a/.github/workflows/lint-pr.yml
+++ b/.github/workflows/lint-pr.yml
@@ -1,0 +1,17 @@
+name: "Lint PR"
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - edited
+      - synchronize
+
+jobs:
+  main:
+    name: Validate PR title
+    runs-on: ubuntu-latest
+    steps:
+      - uses: amannn/action-semantic-pull-request@v4
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .?*
+!.github
 !.dockerignore
 __pycache__
 **/.DS_Store
@@ -10,3 +11,5 @@ abigenBindings/
 _ixh/
 hmny_wallets/
 tmp/
+devnet/docker/icon-bsc/local/
+devnet/docker/icon-bsc/data/


### PR DESCRIPTION
Dependency review action raise an error if any dependency vulnerabilities are introduced. Gitignore no longer ignores .github and now ignores local and data files generated by icon-bsc build steps.

Closes #453