### PR TITLE
docs: add link to roadmap, all-contributors

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,3 +57,6 @@ Please see our quarterly roadmap [here](https://github.com/orgs/icon-project/pro
 <!-- prettier-ignore-end -->
 
 <!-- ALL-CONTRIBUTORS-LIST:END -->
+
+This project follows the [all-contributors](https://allcontributors.org) specification.
+Contributions of any kind are welcome!

--- a/README.md
+++ b/README.md
@@ -44,5 +44,5 @@ For the testnet contract addresses, please check [Testnet Contract Addresses](./
 
 
 ## Roadmap
-
+https://github.com/orgs/icon-project/projects/4
 ## Contributors

--- a/README.md
+++ b/README.md
@@ -44,5 +44,16 @@ For the testnet contract addresses, please check [Testnet Contract Addresses](./
 
 
 ## Roadmap
-https://github.com/orgs/icon-project/projects/4
+
+Please see our quarterly roadmap [here](https://github.com/orgs/icon-project/projects/4).
+
 ## Contributors
+
+<!-- ALL-CONTRIBUTORS-LIST:START - Do not remove or modify this section -->
+<!-- prettier-ignore-start -->
+<!-- markdownlint-disable -->
+
+<!-- markdownlint-restore -->
+<!-- prettier-ignore-end -->
+
+<!-- ALL-CONTRIBUTORS-LIST:END -->


### PR DESCRIPTION
Added link to roadmap created in GitHub to the readme section



## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have documented my code in accordance with the [documentation guidelines](https://github.com/icon-project/community/blob/main/guidelines/technical/software-development-guidelines.md#documentation)
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have run the unit tests
- [ ] I only have one commit (if not, squash them into one commit).
- [ ] I have a descriptive commit message that adheres to the [commit message guidelines](https://github.com/icon-project/community/blob/main/guidelines/technical/software-development-guidelines.md#commit-messages)

> Please review the [CONTRIBUTING.md](/CONTRIBUTING.md) file for detailed contributing guidelines.
